### PR TITLE
Fix JavaScript spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ I'm a full stack developer currently working as a HubSpot and web developer, uti
 
 
 ## 🛠 Technologies & Tools
-![Javascript](https://cdn.jsdelivr.net/npm/devicons@1.8.0/!SVG/js_badge.svg "Javascript")
+![JavaScript](https://cdn.jsdelivr.net/npm/devicons@1.8.0/!SVG/js_badge.svg "JavaScript")
 ![React](https://cdn.jsdelivr.net/npm/devicons@1.8.0/!SVG/react.svg "React")
 <img src="https://cdn.jsdelivr.net/npm/simple-icons@3.13.0/icons/graphql.svg" alt="GraphQL" title="GraphQL" width="32" />
 ![Git](https://cdn.jsdelivr.net/npm/devicons@1.8.0/!SVG/git.svg "Git")


### PR DESCRIPTION
## Summary
- fix the spelling of JavaScript in README

## Testing
- `grep -ni javascript README.md`